### PR TITLE
Add support for selective serialization modifiers

### DIFF
--- a/docs/serialize.md
+++ b/docs/serialize.md
@@ -32,6 +32,8 @@ columns 1
         t6["withDoNotParseNullValues()"]
         t7["withIgnoreProperties()"]
         t8["withoutIgnoreProperties()"]
+        t9["withOnlyProperties()"]
+        t10["withoutOnlyProperties()"]
     end
 
     down2<["&nbsp;&nbsp;&nbsp;"]>(down)
@@ -105,16 +107,18 @@ For detailed formatter documentation including customization options, configurat
 
 These are the possible modifiers for parsing:
 
-| Method                   | Description                                                  |
-|--------------------------|--------------------------------------------------------------|
-| withDoNotParseNullValues | Ignore null elements                                         |
-| withDoNotParse           | Ignore some classes and return them as is                    |
-| withOnlyString           | Return only string elements                                  |
-| withMethodPattern        | Use the pattern to convert method into property              |
-| withMethodGetPrefix      | Set the prefix for getter methods (default is 'get')         |
-| withStopAtFirstLevel     | Only parse the first level of nested objects                 |
-| withIgnoreProperties     | Specify properties to ignore during serialization            |
-| withoutIgnoreProperties  | Clear the list of properties to ignore during serialization  |
+| Method                   | Description                                                             |
+|--------------------------|-------------------------------------------------------------------------|
+| withDoNotParseNullValues | Ignore null elements                                                    |
+| withDoNotParse           | Ignore some classes and return them as is                               |
+| withOnlyString           | Return only string elements                                             |
+| withMethodPattern        | Use the pattern to convert method into property                         |
+| withMethodGetPrefix      | Set the prefix for getter methods (default is 'get')                    |
+| withStopAtFirstLevel     | Only parse the first level of nested objects                            |
+| withIgnoreProperties     | Specify properties to exclude during serialization (denylist)           |
+| withoutIgnoreProperties  | Clear the denylist                                                      |
+| withOnlyProperties       | Specify the only properties to include during serialization (allowlist) |
+| withoutOnlyProperties    | Clear the allowlist                                                     |
 
 #### Ignore null elements: `withDoNotParseNullValues()`
 

--- a/src/Serialize.php
+++ b/src/Serialize.php
@@ -32,6 +32,8 @@ class Serialize
     protected bool $serializeNull = true;
     protected array $ignoreProperties = [];
     protected array $ignorePropertiesMap = [];
+    protected array $onlyProperties = [];
+    protected array $onlyPropertiesMap = [];
 
     private const string METHOD_PATTERN_SEARCH_KEY = "search";
     private const string METHOD_PATTERN_REPLACE_KEY = "replace";
@@ -263,10 +265,14 @@ class Serialize
         $copyNulls = $this->isCopyingNullValues();
         $ignorePropertiesMap = $this->ignorePropertiesMap;
         $hasIgnoreProperties = !empty($ignorePropertiesMap);
+        $onlyPropertiesMap = $this->onlyPropertiesMap;
+        $hasOnlyProperties = !empty($onlyPropertiesMap);
 
         foreach ($array as $key => $value) {
-            // Fast check if property should be ignored - using isset is much faster than in_array
             if ($hasIgnoreProperties && isset($ignorePropertiesMap[$key])) {
+                continue;
+            }
+            if ($hasOnlyProperties && !isset($onlyPropertiesMap[$key])) {
                 continue;
             }
 
@@ -405,8 +411,10 @@ class Serialize
     // Once the properties are cached, we can get the array based on the cached properties
     protected function setValue(array &$result, object $object, string $propertyName, array $cachedProperty, ?string $attributeClass, ?Closure $attributeFunction): void
     {
-        // Fast check if property should be ignored - using isset is much faster than in_array
         if (isset($this->ignorePropertiesMap[$propertyName])) {
+            return;
+        }
+        if (!empty($this->onlyPropertiesMap) && !isset($this->onlyPropertiesMap[$propertyName])) {
             return;
         }
 
@@ -664,6 +672,20 @@ class Serialize
     {
         $this->ignoreProperties = [];
         $this->ignorePropertiesMap = [];
+        return $this;
+    }
+
+    public function withOnlyProperties(array $properties): static
+    {
+        $this->onlyProperties = $properties;
+        $this->onlyPropertiesMap = array_flip($properties);
+        return $this;
+    }
+
+    public function withoutOnlyProperties(): static
+    {
+        $this->onlyProperties = [];
+        $this->onlyPropertiesMap = [];
         return $this;
     }
 

--- a/tests/Serialize/SerializerCfgTest.php
+++ b/tests/Serialize/SerializerCfgTest.php
@@ -178,6 +178,38 @@ class SerializerCfgTest extends TestCase
             "Processing similar objects should benefit from reflection caching");
     }
     
+    public function testOnlyProperties(): void
+    {
+        $model = new stdClass();
+        $model->id = 1;
+        $model->name = "Test";
+        $model->secret = "hidden";
+
+        $serializer = Serialize::from($model);
+        $serializer->withOnlyProperties(['id', 'name']);
+        $result = $serializer->toArray();
+
+        $this->assertEquals(['id' => 1, 'name' => "Test"], $result);
+        $this->assertArrayNotHasKey('secret', $result);
+
+        $serializer->withoutOnlyProperties();
+        $result = $serializer->toArray();
+
+        $this->assertEquals(['id' => 1, 'name' => "Test", 'secret' => "hidden"], $result);
+    }
+
+    public function testOnlyPropertiesWithObject(): void
+    {
+        $model = new ModelGetter(10, 'John');
+
+        $result = Serialize::from($model)
+            ->withOnlyProperties(['Name'])
+            ->toArray();
+
+        $this->assertEquals(['Name' => 'John'], $result);
+        $this->assertArrayNotHasKey('Id', $result);
+    }
+
     public function testIgnoreProperties(): void
     {
         $model = new stdClass();


### PR DESCRIPTION
### Description

This pull request introduces two new methods for serialization: `withOnlyProperties()` and `withoutOnlyProperties()`. These allow for more fine-grained control over serializing specific properties by either including or excluding them selectively.

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

### Checklist
- [ ] Code compiles without errors.
- [ ] Tests have been written and pass locally.
- [ ] Relevant documentation has been updated.
- [ ] Any dependent changes have been merged and published in downstream modules. 

### Additional Information
N/A