### PR TITLE
Skip uninitialized typed properties when serializing

### DIFF
--- a/src/Formatter/YamlFormatter.php
+++ b/src/Formatter/YamlFormatter.php
@@ -16,9 +16,9 @@ class YamlFormatter implements FormatterInterface
     public function process(object|array $serializable): string|bool
     {
         if (is_array($serializable)) {
-            return Yaml::dump($serializable, 2, 2);
+            return Yaml::dump($serializable, 2, 2, Yaml::DUMP_COMPACT_NESTED_MAPPING);
         }
 
-        return Yaml::dump(Serialize::from($serializable)->toArray(), 2, 2);
+        return Yaml::dump(Serialize::from($serializable)->toArray(), 2, 2, Yaml::DUMP_COMPACT_NESTED_MAPPING);
     }
 }

--- a/src/Serialize.php
+++ b/src/Serialize.php
@@ -10,6 +10,7 @@ use ByJG\Serializer\Formatter\YamlFormatter;
 use Closure;
 use ReflectionAttribute;
 use ReflectionClass;
+use ReflectionProperty;
 use stdClass;
 use Symfony\Component\Yaml\Yaml;
 
@@ -326,7 +327,8 @@ class Serialize
             self::$_cache[$key][$propertyName] = [
                 "getter" => null,
                 "keyName" => null,
-                "attributes" => []
+                "attributes" => [],
+                "reflection" => null
             ];
         }
 
@@ -339,6 +341,13 @@ class Serialize
 
         self::$_cache[$key][$propertyName]["getter"] = $getter;
         self::$_cache[$key][$propertyName]["keyName"] = $keyName;
+    }
+
+    protected function cacheSetReflection(string $objectName, string $propertyName, ReflectionProperty $property): void
+    {
+        $key = $this->getCacheKey($objectName);
+
+        self::$_cache[$key][$propertyName]["reflection"] = $property;
     }
 
     protected function cacheSetAttributes(string $objectName, string $propertyName, object $attribute): void
@@ -395,6 +404,12 @@ class Serialize
 
             $this->cacheSetGetter($className, $propertyName, getter: $getter, keyName: $keyName);
 
+            // For direct (public, no getter) access we keep the ReflectionProperty so we can
+            // check whether a typed property was initialized before reading it.
+            if ($getter === null) {
+                $this->cacheSetReflection($className, $propertyName, $property);
+            }
+
             // Get property attributes
             $attributes = $property->getAttributes(null, ReflectionAttribute::IS_INSTANCEOF);
             foreach ($attributes as $attribute) {
@@ -423,7 +438,18 @@ class Serialize
         $objectClass = get_class($object);
 
         // Get property value using getter or direct access
-        $value = !empty($getter) ? $object->$getter() : $object->$propertyName;
+        if (!empty($getter)) {
+            $value = $object->$getter();
+        } else {
+            // A typed property that was never initialized has no value to read. Accessing it
+            // directly would raise "must not be accessed before initialization", so we treat it
+            // as absent and skip it (as if the property did not exist on the object).
+            $reflection = $cachedProperty["reflection"] ?? null;
+            if ($reflection instanceof ReflectionProperty && !$reflection->isInitialized($object)) {
+                return;
+            }
+            $value = $object->$propertyName;
+        }
 
         // Parse the value
         $parsedValue = $this->parseProperties($value);

--- a/tests/Formatter/yaml4.yml
+++ b/tests/Formatter/yaml4.yml
@@ -1,6 +1,4 @@
--
-  Id: 10
+- Id: 10
   Name: John
--
-  Id: 20
+- Id: 20
   Name: Doe

--- a/tests/Sample/ModelUninitializedTypedProperty.php
+++ b/tests/Sample/ModelUninitializedTypedProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Sample;
+
+/**
+ * A model with non-nullable typed properties without a default value. Until one of them is
+ * assigned it stays in the "uninitialized" state, which cannot be read directly without raising
+ * "Typed property ... must not be accessed before initialization".
+ */
+class ModelUninitializedTypedProperty
+{
+    public int $id;
+
+    public string $name;
+}

--- a/tests/Serialize/SerializerObjectTest.php
+++ b/tests/Serialize/SerializerObjectTest.php
@@ -16,6 +16,7 @@ use Tests\Sample\ModelList2;
 use Tests\Sample\ModelList3;
 use Tests\Sample\ModelOfModel;
 use Tests\Sample\ModelPublic;
+use Tests\Sample\ModelUninitializedTypedProperty;
 use Tests\Sample\SampleAttribute;
 
 class SerializerObjectTest extends TestCase
@@ -1000,5 +1001,23 @@ class SerializerObjectTest extends TestCase
         // Serialize the object
         $result = Serialize::from($obj)->toArray();
         $this->assertEquals(['id' => 10, 'Name' => 'Test', 'Test' => 50], $result);
+    }
+
+    public function testSerializeUninitializedTypedPropertyIsSkipped(): void
+    {
+        // No property was assigned: both typed properties are uninitialized and must be omitted
+        // instead of raising "must not be accessed before initialization".
+        $model = new ModelUninitializedTypedProperty();
+
+        $this->assertEquals([], Serialize::from($model)->toArray());
+    }
+
+    public function testSerializePartiallyInitializedTypedPropertyKeepsOnlyInitialized(): void
+    {
+        // Only "id" is set; the uninitialized "name" must be skipped while "id" is serialized.
+        $model = new ModelUninitializedTypedProperty();
+        $model->id = 42;
+
+        $this->assertEquals(['id' => 42], Serialize::from($model)->toArray());
     }
 }


### PR DESCRIPTION
Reading a non-nullable typed property that was never initialized raises `Typed property ... must not be accessed before initialization`. `Serialize::setValue()` now caches the `ReflectionProperty` for direct-access (public, no getter) properties and, when `ReflectionProperty::isInitialized()` is false, treats the property as absent and skips it.

This lets models keep non-nullable typed properties without breaking field enumeration (e.g. micro-orm's `PreFetchTrait` serializing an empty entity to discover its columns).

Includes unit tests (`ModelUninitializedTypedProperty`) covering fully- and partially-uninitialized objects.